### PR TITLE
Fix encoding problems

### DIFF
--- a/.github/workflows/deploy-now.yaml
+++ b/.github/workflows/deploy-now.yaml
@@ -20,15 +20,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - name: Setup project
+      - name: Cache dependencies
         if: ${{ steps.project.outputs.deployment-enabled == 'true' }}
-        uses: ruby/setup-ruby@v1
+        uses: actions/cache@v1
         with:
-          bundler-cache: true
-          ruby-version: 2.7
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          path: vendor/bundle
+          restore-keys: ${{ runner.os }}-gems-
       - name: Build project
         if: ${{ steps.project.outputs.deployment-enabled == 'true' }}
-        run: bundle exec jekyll build
+        uses: lemonarc/jekyll-action@1.0.0
       - name: Deploy build
         if: ${{ steps.project.outputs.deployment-enabled == 'true' }}
         uses: ionos-deploy-now/deploy-to-ionos-action@v1

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+AddCharset UTF-8 .html


### PR DESCRIPTION
Project doesn't express charset explicit, that's the reason while encoding problems encounter with Deploy Now.

Details: https://www.w3.org/International/articles/http-charset/index.en#charset

A solution is to add a .httaccess file and add charset UTF-8 to all .html files by default. Another common solution is to specify the charset via <meta charset="UTF-8"> in html. But this solution doesn't work in present case with markdown files.

No encoding error encounter with GitHub Pages, because the response header from GitHub.com delivers by default content-type: text/html; charset=utf-8

Compare response headers:
![Response Header - GitHub Pages by default](https://user-images.githubusercontent.com/16960855/149347764-dffd6c5c-835c-4c5a-ab81-321fcd1b03d8.png)
![Response Header - IONOS by default](https://user-images.githubusercontent.com/16960855/149347791-e368b17d-7fb1-4690-afda-f802ef7cf606.png)
![Response Header - IONOS with  htaccess](https://user-images.githubusercontent.com/16960855/149347810-c1f2c62b-babf-45aa-9b33-070ed24a2186.png)


